### PR TITLE
MAYN-193 Added RedirectMiddleware and changed the way we enable a default site

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,4 +4,5 @@ data_file = .coverage
 source=django_sites_extensions
 omit =
     django_sites_extensions/settings*
+    django_sites_extensions/tests*
     *migrations*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .DEFAULT_GOAL := test
 
-.PHONY: clean compile_translations dummy_translations extract_translations fake_translations help html_coverage \
-	migrate pull_translations push_translations quality requirements test update_translations validate
+.PHONY: clean help migrate quality local-requirements requirements test validate html_coverage
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"

--- a/README.rst
+++ b/README.rst
@@ -23,20 +23,39 @@ provided by the framework that adds the current site to incoming requests does n
 you to fall back to a site that you can configure in settings in case the current site
 cannot be determined from the host of the incoming request.
 
-The django_sites_extensions.middleware.CurrentSiteWithDefaultMiddleware provided by this package
-extends django.contrib.sites.middleware.CurrentSiteMiddleware to allow for this use case. To enable
-this functionality in your Django project::
+This Django app provided by this package overcomes this issue by monkey patching the
+django.contrib.sites.models.SiteManager.get_current() function which is called by the
+CurrentSiteMiddleware to determine the current site. The patched version of this function
+will first try to determine the current site by checking the host of the incoming request
+and attempting to match a site by domain. If a site cannot be found this way, it will fall
+back to the default site configured by setting the SITE_ID setting.
+
+To enable this functionality in your Django project::
 
 Install this package in your python environment::
 
     $ pip install edx-django-sites-extensions
 
-Replace :code:`django.contrib.sites.middleware.CurrentSiteMiddleware` with
-:code:`django_sites_extensions.middleware.CurrentSiteWithDefaultMiddleware`.
+Add :code:`django.contrib.sites.middleware.CurrentSiteMiddleware` to your :code:`MIDDLEWARE_CLASSES` list.
 
-Add default site setting to Django settings::
+Set the :code:`SITE_ID` setting::
 
-    DEFAULT_SITE_ID = 1
+    SITE_ID = 1
+
+This package also provides a mechanism for settings up URL redirects for your application.
+It makes use of the Django redirects app and provides middleware which will check for
+Redirect models whose old_path field matches the path of the incoming request and redirects
+those requests to the new_path of the Redirect model.
+
+To enable this functionality in your Django project::
+
+Install this package in your python environment::
+
+    $ pip install edx-django-sites-extensions
+
+Add :code:`django_sites_extensions.middleware.RedirectMiddleware` to your :code:`MIDDLEWARE_CLASSES` list.
+
+You can then use Django admin to create Redirect models.
 
 Documentation (please modify)
 -----------------------------

--- a/django_sites_extensions/__init__.py
+++ b/django_sites_extensions/__init__.py
@@ -1,0 +1,2 @@
+""" django_sites_extensions main module """
+default_app_config = 'django_sites_extensions.apps.DjangoSitesExtensionsConfig'

--- a/django_sites_extensions/apps.py
+++ b/django_sites_extensions/apps.py
@@ -1,0 +1,13 @@
+""" django_sites_extensions application configuration """
+from django.apps import AppConfig
+
+
+class DjangoSitesExtensionsConfig(AppConfig):
+    """ django_sites_extensions application configuration """
+    name = 'django_sites_extensions'
+    verbose_name = 'Django Sites Extensions'
+
+    def ready(self):
+        """ Set up for django_sites_extensions app """
+        from django_sites_extensions import models
+        from django_sites_extensions import signals

--- a/django_sites_extensions/middleware.py
+++ b/django_sites_extensions/middleware.py
@@ -1,29 +1,27 @@
 """
-Django sites framework middleware extensions for Open edX
+Django middleware extensions for Open edX
 """
 from django.conf import settings
-from django.contrib.sites.middleware import CurrentSiteMiddleware
-from django.contrib.sites.models import Site
-from django.core.exceptions import ImproperlyConfigured
+from django.core.cache import cache
+from django.contrib.redirects.models import Redirect
+from django.shortcuts import redirect
 
 
-class CurrentSiteWithDefaultMiddleware(CurrentSiteMiddleware):
+class RedirectMiddleware(object):
     """
-    This is an extension of Django's CurrentSiteMiddleware. This extension
-    allows for the specification of a default site to use in the case when
-    the current site cannot be determined by examining the host of the
-    incoming request.
-
-    When using this middleware you should define a DEFAULT_SITE_ID setting
-    which indicates the default site to fall back to.
+    Redirects requests for URLs persisted using the django.contrib.redirects.models.Redirect model.
     """
-
     def process_request(self, request):
-        try:
-            super(CurrentSiteWithDefaultMiddleware, self).process_request(request)
-        except (Site.DoesNotExist, ImproperlyConfigured):
-            site_id = getattr(settings, 'DEFAULT_SITE_ID', '')
-            if site_id:
-                request.site = Site.objects.get(pk=site_id)  # pylint: disable=no-member
-            else:
-                raise
+        """
+        Redirects the current request if there is a matching Redirect model
+        with the current request URL as the old_path field.
+        """
+        site = request.site
+        cache_key = '{prefix}-{site}'.format(prefix=settings.REDIRECT_CACHE_KEY_PREFIX, site=site.domain)
+        redirects = cache.get(cache_key)
+        if redirects is None:
+            redirects = {redirect.old_path: redirect.new_path for redirect in Redirect.objects.filter(site=site)}
+            cache.set(cache_key, redirects, settings.REDIRECT_CACHE_TIMEOUT)
+        redirect_to = redirects.get(request.path)
+        if redirect_to:
+            return redirect(redirect_to, permanent=True)

--- a/django_sites_extensions/models.py
+++ b/django_sites_extensions/models.py
@@ -1,0 +1,34 @@
+""" Django Sites framework models overrides """
+from django.contrib.sites.models import Site, SiteManager
+from django.core.exceptions import ImproperlyConfigured
+
+
+def patched_get_current(self, request=None):
+    """
+    Monkey patched version of Django's SiteManager.get_current() function.
+
+    Returns the current Site based on a given request or the SITE_ID in
+    the project's settings. If a request is given attempts to match a site
+    with domain matching request.get_host(). If a request is not given or
+    a site cannot be found based on the host of the request, we return the
+    site which matches the configured SITE_ID setting.
+    """
+    from django.conf import settings
+    if request:
+        try:
+            return self._get_site_by_request(request)  # pylint: disable=protected-access
+        except Site.DoesNotExist:
+            pass
+
+    if getattr(settings, 'SITE_ID', ''):
+        return self._get_site_by_id(settings.SITE_ID)  # pylint: disable=protected-access
+
+    raise ImproperlyConfigured(
+        "You're using the Django \"sites framework\" without having "
+        "set the SITE_ID setting. Create a site in your database and "
+        "set the SITE_ID setting or pass a request to "
+        "Site.objects.get_current() to fix this error."
+    )
+
+
+SiteManager.get_current = patched_get_current

--- a/django_sites_extensions/settings/base.py
+++ b/django_sites_extensions/settings/base.py
@@ -16,6 +16,7 @@ DEBUG = True
 # Application definition
 
 INSTALLED_APPS = (
+    'django.contrib.redirects',
     'django.contrib.sites',
 )
 
@@ -26,8 +27,11 @@ PROJECT_APPS = (
 INSTALLED_APPS += PROJECT_APPS
 
 MIDDLEWARE_CLASSES = (
-    'django_sites_extensions.middleware.CurrentSiteWithDefaultMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
+    'django_sites_extensions.middleware.RedirectMiddleware',
 )
+
+ROOT_URLCONF = 'django_sites_extensions.tests.urls'
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
@@ -89,3 +93,10 @@ LOGGING = {
         },
     }
 }
+
+############## Settings for RedirectMiddleware ###############
+
+# Setting this to None causes Redirect data to never expire
+# The cache is cleared when Redirect models are saved/deleted
+REDIRECT_CACHE_TIMEOUT = None  # The length of time we cache Redirect model data
+REDIRECT_CACHE_KEY_PREFIX = 'redirects'

--- a/django_sites_extensions/signals.py
+++ b/django_sites_extensions/signals.py
@@ -1,0 +1,16 @@
+""" django_sites_extensions module signals """
+from django.conf import settings
+from django.core.cache import cache
+from django.dispatch import receiver
+from django.db.models.signals import post_delete, post_save
+from django.contrib.redirects.models import Redirect
+
+
+@receiver(post_delete, sender=Redirect)
+@receiver(post_save, sender=Redirect)
+def clear_redirect_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """
+    Clears the Redirect cache
+    """
+    cache_key = '{prefix}-{site}'.format(prefix=settings.REDIRECT_CACHE_KEY_PREFIX, site=instance.site.domain)
+    cache.delete(cache_key)

--- a/django_sites_extensions/tests/test_middleware.py
+++ b/django_sites_extensions/tests/test_middleware.py
@@ -1,48 +1,57 @@
 """
-Tests for Django sites framework middleware extensions
+Tests for middleware extensions
 """
+from django.contrib.redirects.models import Redirect
 from django.contrib.sites.models import Site
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponsePermanentRedirect
 from django.test.testcases import TestCase
-from django.test.utils import override_settings
 
-from django_sites_extensions.middleware import CurrentSiteWithDefaultMiddleware
+from django_sites_extensions.middleware import RedirectMiddleware
 
 
-@override_settings(SITE_ID=None)
-class CurrentSiteWithDefaultMiddlewareTestCase(TestCase):
+class RedirectMiddlewareTestCase(TestCase):
     """
-    Tests for the CurrentSiteWithDefaultMiddleware
+    Test processing a request through the RedirectMiddleware
     """
-    def test_current_site_from_request_host(self):
-        """
-        Test that current site can be determined from request host
-        """
-        request = HttpRequest()
-        request.META['HTTP_HOST'] = 'example.com'
-        middleware = CurrentSiteWithDefaultMiddleware()
-        middleware.process_request(request)
-        self.assertEqual(request.site.id, 1)  # pylint: disable=no-member
 
-    def test_current_site_no_default_set(self):
-        """
-        Test that exception is raised when no default site is defined
-        and the current site cannot be determined from the request host
-        """
-        request = HttpRequest()
-        request.META['HTTP_HOST'] = 'fake-server.com'
-        middleware = CurrentSiteWithDefaultMiddleware()
-        with self.assertRaises(Site.DoesNotExist):
-            middleware.process_request(request)
+    def setUp(self):
+        super(RedirectMiddlewareTestCase, self).setUp()
+        self.middleware = RedirectMiddleware()
+        self.site = Site.objects.get(id=1)  # pylint: disable=no-member
+        self.redirect = Redirect.objects.create(site_id=1, old_path='/foo', new_path='http://example.com/bar')
 
-    @override_settings(DEFAULT_SITE_ID=1)
-    def test_current_site_with_default_set(self):
-        """
-        Test that default site is used when default set is configured
-        and the current site cannot be determined from the request host
-        """
+    def _make_request(self, path):
+        """ Creates an HttpRequest """
         request = HttpRequest()
-        request.META['HTTP_HOST'] = 'fake-server.com'
-        middleware = CurrentSiteWithDefaultMiddleware()
-        middleware.process_request(request)
-        self.assertEqual(request.site.id, 1)  # pylint: disable=no-member
+        request.path = path
+        request.site = self.site
+        return request
+
+    def test_redirect_url(self):
+        """
+        Test that a Redirect URL is redirected
+        """
+        request = self._make_request('/foo')
+        response = self.middleware.process_request(request)
+        self.assertEqual(response.status_code, 301)
+        self.assertTrue(isinstance(response, HttpResponsePermanentRedirect))
+        self.assertEqual(response.get('location'), self.redirect.new_path)
+
+    def test_normal_url(self):
+        """
+        Test that a normal URL is not redirected
+        """
+        request = self._make_request('/bar')
+        self.assertIsNone(self.middleware.process_request(request))
+
+    def test_redirects_cached(self):
+        """
+        Test that Redirect models get cached
+        """
+        request = self._make_request('/bar')
+        with self.assertNumQueries(1):
+            self.middleware.process_request(request)
+
+        request = self._make_request('/bar')
+        with self.assertNumQueries(0):
+            self.middleware.process_request(request)

--- a/django_sites_extensions/tests/test_models.py
+++ b/django_sites_extensions/tests/test_models.py
@@ -1,0 +1,55 @@
+""" Tests for Django Sites framework models overrides """
+from django.contrib.sites.models import Site
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpRequest
+from django.test.testcases import TestCase
+from django.test.utils import override_settings
+
+
+@override_settings(SITE_ID=1)
+class PatchedSiteManagerTestCase(TestCase):
+    """
+    Tests for the patched version of Django's SiteManager.get_current()
+    """
+
+    def setUp(self):
+        super(PatchedSiteManagerTestCase, self).setUp()
+        self.foo_site = Site.objects.create(domain='foo.com')
+
+    def test_current_site_from_request_host(self):
+        """
+        Test that current site can be determined from request host
+        """
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = self.foo_site.domain
+        site = Site.objects.get_current(request)
+        self.assertEqual(site.id, self.foo_site.id)
+
+    def test_current_site_with_default(self):
+        """
+        Test that default site is used when default set is configured
+        and the current site cannot be determined from the request host
+        """
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = 'bar.com'
+        site = Site.objects.get_current(request)
+        self.assertEqual(site.id, 1)
+
+    def test_current_site_with_no_request(self):
+        """
+        Test that default site is used when no request is passed to
+        SiteManager.get_current()
+        """
+        site = Site.objects.get_current()
+        self.assertEqual(site.id, 1)
+
+    @override_settings(SITE_ID=None)
+    def test_current_site_no_default_set(self):
+        """
+        Test that exception is raised when no default site is defined
+        and the current site cannot be determined from the request host
+        """
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = 'bar.com'
+        with self.assertRaises(ImproperlyConfigured):
+            Site.objects.get_current(request)

--- a/django_sites_extensions/tests/urls.py
+++ b/django_sites_extensions/tests/urls.py
@@ -1,0 +1,9 @@
+""" ROOT_URLCONF for tests """
+from django.conf.urls import url
+
+from django_sites_extensions.tests import views
+
+
+urlpatterns = [
+    url(r'^$', views.test),
+]

--- a/django_sites_extensions/tests/views.py
+++ b/django_sites_extensions/tests/views.py
@@ -1,0 +1,6 @@
+""" Views used only for test setup """
+
+
+def test(request):  # pylint: disable=unused-argument
+    """ Placeholder test view """
+    pass

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as a, open('AUTHORS') as b:
 
 setup(
     name='edx-django-sites-extensions',
-    version='1.0.0',
+    version='2.0.0',
     description='Custom extensions for the Django sites framework',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
This adds support to this package for allowing permanent redirects to be configured for your project using the Django admin. This can be configured in your Django project by adding the `django_sites_extensions.middleware.RedirectMiddleware` to your project's `MIDDLEWARE_CLASSES` list and adding Redirect models using the Django admin.

This change set also changes the way this package supports a default Site when using the Django sites framework. Instead of using a custom middleware class which wraps Django's CurrentSiteMiddleware, we are now monkey patching SiteManager.get_current which is the lower level function that gets called to determine the current site. This will prevent issues we were seeing with code that called SiteManager.get_current directly instead of retrieving the current site from the request object.

@mattdrayer @saleem-latif 