### PR TITLE
WIP WL-589 Add Site model cache timeout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,12 +23,22 @@ provided by the framework that adds the current site to incoming requests does n
 you to fall back to a site that you can configure in settings in case the current site
 cannot be determined from the host of the incoming request.
 
-This Django app provided by this package overcomes this issue by monkey patching the
+The Django app provided by this package overcomes this issue by monkey patching the
 django.contrib.sites.models.SiteManager.get_current() function which is called by the
 CurrentSiteMiddleware to determine the current site. The patched version of this function
 will first try to determine the current site by checking the host of the incoming request
 and attempting to match a site by domain. If a site cannot be found this way, it will fall
 back to the default site configured by setting the SITE_ID setting.
+
+Another issue with the Django "sites" framework is that it uses an in-memory cache of Site
+models which makes it difficult to update models associated with the Site model via Django
+admin and have those updates be reflected across all Python processes in a mulit-process
+application environment.
+
+Again the Django app provided by this package monkey patches the private SiteManager query
+functions that implement the in-memory caching mechanism to add a configurable timeout to
+the Site cache allowing model updates to be reflected across all processes after the specified
+timeout.
 
 To enable this functionality in your Django project::
 

--- a/django_sites_extensions/models.py
+++ b/django_sites_extensions/models.py
@@ -1,6 +1,25 @@
 """ Django Sites framework models overrides """
-from django.contrib.sites.models import Site, SiteManager
+import datetime
+
+from django.contrib.sites.models import Site, SiteManager, SITE_CACHE
 from django.core.exceptions import ImproperlyConfigured
+
+
+# Dict which maps Site id/domain to a datetime
+# when the corresponding when the corresponding
+# Site model cached in SITE_CACHE should be flushed.
+SITE_CACHE_TIMEOUTS = {}
+
+
+def get_site_cache_ttl():
+    """
+    Get the SITE_CACHE_TTL timedelta.
+
+    Defaults to 5 minutes if SITE_CACHE_TTL has not been configured in application settings.
+    """
+    # Imported here to avoid circular import
+    from django.conf import settings
+    return datetime.timedelta(0, getattr(settings, 'SITE_CACHE_TTL', 300))
 
 
 def patched_get_current(self, request=None):
@@ -13,6 +32,7 @@ def patched_get_current(self, request=None):
     a site cannot be found based on the host of the request, we return the
     site which matches the configured SITE_ID setting.
     """
+    # Imported here to avoid circular import
     from django.conf import settings
     if request:
         try:
@@ -31,4 +51,49 @@ def patched_get_current(self, request=None):
     )
 
 
+def patched_get_site_by_id(self, site_id):
+    """
+    Monkey patched version of Django's SiteManager._get_site_by_id() function.
+
+    Adds a configurable timeout to the in-memory SITE_CACHE for each cached Site.
+    This allows for the use of an in-memory cache for Site models, avoiding one
+    or more DB hits on every request made to the Django application, but also allows
+    for changes made to models associated with the Site model and accessed via the
+    Site model's relationship accessors to take effect without having to manual
+    recycle all Django worker processes active in an application environment.
+    """
+    now = datetime.datetime.utcnow()
+    site = SITE_CACHE.get(site_id)
+    cache_timeout = SITE_CACHE_TIMEOUTS.get(site_id, now)
+    if not site or cache_timeout <= now:
+        site = self.get(pk=site_id)
+        SITE_CACHE[site_id] = site
+        SITE_CACHE_TIMEOUTS[site_id] = now + get_site_cache_ttl()
+    return SITE_CACHE[site_id]
+
+
+def patched_get_site_by_request(self, request):
+    """
+    Monkey patched version of Django's SiteManager._get_site_by_request() function.
+
+    Adds a configurable timeout to the in-memory SITE_CACHE for each cached Site.
+    This allows for the use of an in-memory cache for Site models, avoiding one
+    or more DB hits on every request made to the Django application, but also allows
+    for changes made to models associated with the Site model and accessed via the
+    Site model's relationship accessors to take effect without having to manual
+    recycle all Django worker processes active in an application environment.
+    """
+    host = request.get_host()
+    now = datetime.datetime.utcnow()
+    site = SITE_CACHE.get(host)
+    cache_timeout = SITE_CACHE_TIMEOUTS.get(host, now)
+    if not site or cache_timeout <= now:
+        site = self.get(domain__iexact=host)
+        SITE_CACHE[host] = site
+        SITE_CACHE_TIMEOUTS[host] = now + get_site_cache_ttl()
+    return SITE_CACHE[host]
+
+
 SiteManager.get_current = patched_get_current
+SiteManager._get_site_by_id = patched_get_site_by_id  # pylint: disable=protected-access
+SiteManager._get_site_by_request = patched_get_site_by_request  # pylint: disable=protected-access

--- a/django_sites_extensions/tests/test_models.py
+++ b/django_sites_extensions/tests/test_models.py
@@ -1,9 +1,13 @@
 """ Tests for Django Sites framework models overrides """
+import datetime
+
 from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.test.testcases import TestCase
 from django.test.utils import override_settings
+
+from django_sites_extensions.models import SITE_CACHE_TIMEOUTS
 
 
 @override_settings(SITE_ID=1)
@@ -15,6 +19,57 @@ class PatchedSiteManagerTestCase(TestCase):
     def setUp(self):
         super(PatchedSiteManagerTestCase, self).setUp()
         self.foo_site = Site.objects.create(domain='foo.com')
+
+    def test_site_cache_timeout_when_none(self):
+        """
+        Test site cache when SITE_CACHE_TIMEOUT is None for the given site.
+        """
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = self.foo_site.domain
+
+        # Test getting current site by request host
+        site = Site.objects.get_current(request)
+        with self.assertNumQueries(0):
+            site = Site.objects.get_current(request)
+
+        del SITE_CACHE_TIMEOUTS[site.domain]
+        with self.assertNumQueries(1):
+            site = Site.objects.get_current(request)
+
+        # Test getting current site by default site ID
+        site = Site.objects.get_current()
+        with self.assertNumQueries(0):
+            site = Site.objects.get_current()
+
+        del SITE_CACHE_TIMEOUTS[site.id]
+        with self.assertNumQueries(1):
+            site = Site.objects.get_current()
+
+    def test_site_cache_timeout_when_expired(self):
+        """
+        Test site cache when SITE_CACHE_TIMEOUT is expired for the given site.
+        """
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = self.foo_site.domain
+        past = datetime.datetime.utcnow() - datetime.timedelta(0, 300)
+
+        # Test getting current site by request host
+        site = Site.objects.get_current(request)
+        with self.assertNumQueries(0):
+            site = Site.objects.get_current(request)
+
+        SITE_CACHE_TIMEOUTS[site.domain] = past
+        with self.assertNumQueries(1):
+            site = Site.objects.get_current(request)
+
+        # Test getting current site by default site ID
+        site = Site.objects.get_current()
+        with self.assertNumQueries(0):
+            site = Site.objects.get_current()
+
+        SITE_CACHE_TIMEOUTS[site.id] = past
+        with self.assertNumQueries(1):
+            site = Site.objects.get_current()
 
     def test_current_site_from_request_host(self):
         """

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,16 +1,18 @@
 Getting Started
 ===============
-Install this package in your python environment:
-
-.. code-block:: bash
+Install this package in your python environment::
 
     $ pip install edx-django-sites-extensions
 
-Replace :code:`django.contrib.sites.middleware.CurrentSiteMiddleware` with
-:code:`django_sites_extensions.middleware.CurrentSiteWithDefaultMiddleware`.
+Add :code:`django.contrib.sites.middleware.CurrentSiteMiddleware` to your :code:`MIDDLEWARE_CLASSES` list.
 
-Add default site setting to Django settings:
+Set the :code:`SITE_ID` setting::
 
-.. code-block:: bash
+    SITE_ID = 1
 
-    DEFAULT_SITE_ID = 1
+Set up RedirectMiddleware
+-------------------------
+
+Add :code:`django_sites_extensions.middleware.RedirectMiddleware` to your :code:`MIDDLEWARE_CLASSES` list.
+
+You can then use Django admin to create Redirect models.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as a, open('AUTHORS') as b:
 
 setup(
     name='edx-django-sites-extensions',
-    version='2.0.1',
+    version='2.1.0',
     description='Custom extensions for the Django sites framework',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
This PR monkey patches 2 additional `django.contrib.sites.models.SiteManager` functions adding a per-site timeout to the in-memory Site model cache employed by the Django sites framework.

This will allow us make updates to models associated with the Site model in Django admin while minimizing the additional database queries that will need to be performed.

**Sandbox:** https://mitpe.sandbox.edx.org
**Related PR:** https://github.com/edx/edx-platform/pull/13374

A simple way to test this on the sandbox is to edit the SiteConfiguration of one of the sites in Django admin, toggle the value of `ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER`, wait 5 minutes, click the header logo in LMS, and observe that your change has taken effect.