### PR TITLE
WL-589 Use django timezone utility to create datetime

### DIFF
--- a/django_sites_extensions/models.py
+++ b/django_sites_extensions/models.py
@@ -3,6 +3,7 @@ import datetime
 
 from django.contrib.sites.models import Site, SiteManager, SITE_CACHE
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import timezone
 
 
 # Dict which maps Site id/domain to a datetime
@@ -62,7 +63,7 @@ def patched_get_site_by_id(self, site_id):
     Site model's relationship accessors to take effect without having to manual
     recycle all Django worker processes active in an application environment.
     """
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
     site = SITE_CACHE.get(site_id)
     cache_timeout = SITE_CACHE_TIMEOUTS.get(site_id, now)
     if not site or cache_timeout <= now:
@@ -84,7 +85,7 @@ def patched_get_site_by_request(self, request):
     recycle all Django worker processes active in an application environment.
     """
     host = request.get_host()
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
     site = SITE_CACHE.get(host)
     cache_timeout = SITE_CACHE_TIMEOUTS.get(host, now)
     if not site or cache_timeout <= now:

--- a/django_sites_extensions/tests/test_models.py
+++ b/django_sites_extensions/tests/test_models.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.test.testcases import TestCase
 from django.test.utils import override_settings
+from django.utils import timezone
 
 from django_sites_extensions.models import SITE_CACHE_TIMEOUTS
 
@@ -51,7 +52,7 @@ class PatchedSiteManagerTestCase(TestCase):
         """
         request = HttpRequest()
         request.META['HTTP_HOST'] = self.foo_site.domain
-        past = datetime.datetime.utcnow() - datetime.timedelta(0, 300)
+        past = timezone.now() - datetime.timedelta(0, 300)
 
         # Test getting current site by request host
         site = Site.objects.get_current(request)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as a, open('AUTHORS') as b:
 
 setup(
     name='edx-django-sites-extensions',
-    version='2.1.0',
+    version='2.1.1',
     description='Custom extensions for the Django sites framework',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
We need to use `django.utils.timezone` to create tz-aware datetimes.
