### PR TITLE
[BD-18] Replace django test command with pytest and remove nose dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ assets/
 .coverage
 htmlcov
 .tox
-nosetests.xml
 unittests.xml
 
 ### Internationalization artifacts

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ quality:
 	tox -e quality
 
 requirements:
-	pip install -r test_requirements.txt
+	pip install -qr requirements/pip_tools.txt
+	pip-sync requirements/test.txt
 
 test:
 	tox

--- a/django_sites_extensions/apps.py
+++ b/django_sites_extensions/apps.py
@@ -13,5 +13,6 @@ class DjangoSitesExtensionsConfig(AppConfig):
         """ Set up for django_sites_extensions app """
         # pylint: disable=unused-variable
         # pylint: disable=unused-import
+        # pylint: disable=import-outside-toplevel
         from django_sites_extensions import models
         from django_sites_extensions import signals

--- a/django_sites_extensions/models.py
+++ b/django_sites_extensions/models.py
@@ -22,7 +22,7 @@ def get_site_cache_ttl():
     Defaults to 5 minutes if SITE_CACHE_TTL has not been configured in application settings.
     """
     # Imported here to avoid circular import
-    from django.conf import settings
+    from django.conf import settings  # pylint: disable=import-outside-toplevel
     return datetime.timedelta(0, getattr(settings, 'SITE_CACHE_TTL', 300))
 
 
@@ -37,7 +37,7 @@ def patched_get_current(self, request=None):
     site which matches the configured SITE_ID setting.
     """
     # Imported here to avoid circular import
-    from django.conf import settings
+    from django.conf import settings  # pylint: disable=import-outside-toplevel
     if request:
         try:
             return self._get_site_by_request(request)  # pylint: disable=protected-access

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2020.1              # via django
 sqlparse==0.3.1           # via django

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.txt
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,23 +6,23 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
-certifi==2020.4.5.1       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in
 docutils==0.16            # via sphinx
-idna==2.9                 # via requests
+idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
-packaging==20.3           # via sphinx
+packaging==20.4           # via sphinx
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytz==2020.1              # via babel, django
-requests==2.23.0          # via sphinx
-six==1.14.0               # via packaging
+requests==2.24.0          # via sphinx
+six==1.15.0               # via packaging
 snowballstemmer==2.0.0    # via sphinx
-sphinx-rtd-theme==0.4.3   # via -r requirements/doc.in
-sphinx==3.0.3             # via -r requirements/doc.in, sphinx-rtd-theme
+sphinx-rtd-theme==0.5.0   # via -r requirements/doc.in
+sphinx==3.1.2             # via -r requirements/doc.in, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.1          # via -r requirements/pip_tools.in
-six==1.14.0               # via pip-tools
+pip-tools==5.2.1          # via -r requirements/pip_tools.in
+six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,9 +6,9 @@
 
 coverage
 django-dynamic-fixture
-django-nose
 edx-lint
 mock
-nose-ignore-docstring
 pep8
+pytest-cov
+pytest-django
 twine

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,44 +5,52 @@
 #    make upgrade
 #
 astroid==2.3.3            # via pylint, pylint-celery
+attrs==19.3.0             # via pytest
 bleach==3.1.5             # via readme-renderer
-certifi==2020.4.5.1       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-coverage==5.1             # via -r requirements/test.in
+coverage==5.2             # via -r requirements/test.in, pytest-cov
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-nose==1.4.6        # via -r requirements/test.in
 docutils==0.16            # via readme-renderer
-edx-lint==1.4.1           # via -r requirements/test.in
-idna==2.9                 # via requests
+edx-lint==1.5.0           # via -r requirements/test.in
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-nose-ignore-docstring==0.2  # via -r requirements/test.in
-nose==1.3.7               # via django-nose
-packaging==20.3           # via bleach
+more-itertools==8.4.0     # via pytest
+packaging==20.4           # via bleach, pytest
+pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via -r requirements/test.in
 pkginfo==1.5.0.1          # via twine
+pluggy==0.13.1            # via pytest
+py==1.9.0                 # via pytest
 pygments==2.6.1           # via readme-renderer
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via packaging
+pytest-cov==2.10.0        # via -r requirements/test.in
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.3             # via pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/base.txt, django
 readme-renderer==26.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.23.0          # via requests-toolbelt, twine
-six==1.14.0               # via astroid, bleach, django-dynamic-fixture, edx-lint, mock, packaging, readme-renderer
+requests==2.24.0          # via requests-toolbelt, twine
+six==1.15.0               # via astroid, bleach, django-dynamic-fixture, edx-lint, mock, packaging, pathlib2, readme-renderer
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-tqdm==4.46.0              # via twine
+tqdm==4.47.0              # via twine
 twine==1.15.0             # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 urllib3==1.25.9           # via requests
+wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via virtualenv
-distlib==0.3.0            # via virtualenv
+appdirs==1.4.4            # via virtualenv
+distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
-packaging==20.3           # via tox
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
+packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-six==1.14.0               # via packaging, tox, virtualenv
-toml==0.10.0              # via tox
-tox==3.15.0               # via -r requirements/tox.in
-virtualenv==20.0.20       # via tox
+six==1.15.0               # via packaging, tox, virtualenv
+toml==0.10.1              # via tox
+tox==3.16.1               # via -r requirements/tox.in
+virtualenv==20.0.26       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,24 +4,24 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via -r requirements/tox.txt, virtualenv
-certifi==2020.4.5.1       # via requests
+appdirs==1.4.4            # via -r requirements/tox.txt, virtualenv
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.22           # via -r requirements/travis.in
-coverage==5.1             # via codecov
-distlib==0.3.0            # via -r requirements/tox.txt, virtualenv
+codecov==2.1.7            # via -r requirements/travis.in
+coverage==5.2             # via codecov
+distlib==0.3.1            # via -r requirements/tox.txt, virtualenv
 filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
-idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via -r requirements/tox.txt, importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/tox.txt, virtualenv
-packaging==20.3           # via -r requirements/tox.txt, tox
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via -r requirements/tox.txt, pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/tox.txt, virtualenv
+packaging==20.4           # via -r requirements/tox.txt, tox
 pluggy==0.13.1            # via -r requirements/tox.txt, tox
-py==1.8.1                 # via -r requirements/tox.txt, tox
+py==1.9.0                 # via -r requirements/tox.txt, tox
 pyparsing==2.4.7          # via -r requirements/tox.txt, packaging
-requests==2.23.0          # via codecov
-six==1.14.0               # via -r requirements/tox.txt, packaging, tox, virtualenv
-toml==0.10.0              # via -r requirements/tox.txt, tox
-tox==3.15.0               # via -r requirements/tox.txt
+requests==2.24.0          # via codecov
+six==1.15.0               # via -r requirements/tox.txt, packaging, tox, virtualenv
+toml==0.10.1              # via -r requirements/tox.txt, tox
+tox==3.16.1               # via -r requirements/tox.txt
 urllib3==1.25.9           # via requests
-virtualenv==20.0.20       # via -r requirements/tox.txt, tox
+virtualenv==20.0.26       # via -r requirements/tox.txt, tox
 zipp==1.2.0               # via -r requirements/tox.txt, importlib-metadata, importlib-resources

--- a/test_settings.py
+++ b/test_settings.py
@@ -15,7 +15,6 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.redirects',
     'django.contrib.sites',
-    'django_nose',
     'django_sites_extensions',
 )
 
@@ -34,13 +33,6 @@ MIDDLEWARE = (
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'django_sites_extensions.middleware.RedirectMiddleware',
 )
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '--with-ignore-docstrings',
-    '--logging-level=DEBUG',
-]
 
 ROOT_URLCONF = 'django_sites_extensions.tests.urls'
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py35-django22,py38-django{22,30},quality,docs
 setenv =
  # This allows us to reference test_settings.py
     PYTHONPATH = {toxinidir}
+    DJANGO_SETTINGS_MODULE = test_settings
 
 deps =
     django22: -rrequirements/django.txt
@@ -12,13 +13,11 @@ deps =
     -r requirements/test.txt
 
 commands =
-    python -Wd manage.py test django_sites_extensions --settings=test_settings --with-coverage --cover-package=django_sites_extensions
-    coverage report
+    pytest --cov=django_sites_extensions
 
 [testenv:quality]
-commands = 
+commands =
     pep8 --config=.pep8 django_sites_extensions
     pylint --rcfile pylintrc django_sites_extensions
     python setup.py bdist_wheel
     twine check dist/*
-


### PR DESCRIPTION
**Description:**

- Remove "django_nose" dependency.
- Add "pytest-cov" package.
- Update packages with "make upgrade".
- Run test with pytest instead of django-test.
- Update "make requirements" command.