### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ Part of `edX code <http://code.edx.org/>`_.
 
 edx-django-sites-extensions  |Travis|_ |Codecov|_
 =================================================
-.. |Travis| image:: https://travis-ci.org/edx/edx-django-sites-extensions.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/edx-django-sites-extensions?branch=master
+.. |Travis| image:: https://travis-ci.com/edx/edx-django-sites-extensions.svg?branch=master
+.. _Travis: https://travis-ci.com/edx/edx-django-sites-extensions?branch=master
 
 .. |Codecov| image:: http://codecov.io/github/edx/edx-django-sites-extensions/coverage.svg?branch=master
 .. _Codecov: http://codecov.io/github/edx/edx-django-sites-extensions?branch=master


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089