### PR TITLE
fix: Fix `make upgrade`

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.11.0
+asgiref==3.11.1
     # via django
-django==5.2.9
+django==5.2.11
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
-sqlparse==0.5.4
+sqlparse==0.5.5
     # via django

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,11 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==6.2.3
-    # via
-    #   -r requirements/tox.txt
-    #   tox
-chardet==5.2.0
+cachetools==7.0.1
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -20,19 +16,21 @@ distlib==0.4.0
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-filelock==3.20.0
+filelock==3.25.0
     # via
     #   -r requirements/tox.txt
+    #   python-discovery
     #   tox
     #   virtualenv
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/tox.txt
     #   pyproject-api
     #   tox
-platformdirs==4.5.1
+platformdirs==4.9.2
     # via
     #   -r requirements/tox.txt
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -43,9 +41,13 @@ pyproject-api==1.10.0
     # via
     #   -r requirements/tox.txt
     #   tox
-tox==4.32.0
+python-discovery==1.1.0
+    # via
+    #   -r requirements/tox.txt
+    #   virtualenv
+tox==4.47.0
     # via -r requirements/tox.txt
-virtualenv==20.35.4
+virtualenv==21.1.0
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,2 +1,2 @@
-django==5.2.9
-asgiref==3.11.0
+django==5.2.11
+asgiref==3.11.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,19 +6,19 @@
 #
 alabaster==1.0.0
     # via sphinx
-asgiref==3.11.0
+asgiref==3.11.1
     # via django
-babel==2.17.0
+babel==2.18.0
     # via sphinx
-certifi==2025.11.12
+certifi==2026.2.25
     # via requests
 charset-normalizer==3.4.4
     # via requests
-django==5.2.9
+django==5.2.11
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
-docutils==0.21.2
+docutils==0.22.4
     # via
     #   sphinx
     #   sphinx-rtd-theme
@@ -30,22 +30,22 @@ jinja2==3.1.6
     # via sphinx
 markupsafe==3.0.3
     # via jinja2
-packaging==25.0
+packaging==26.0
     # via sphinx
 pygments==2.19.2
     # via sphinx
 requests==2.32.5
     # via sphinx
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
 snowballstemmer==3.0.1
     # via sphinx
-sphinx==8.2.3
+sphinx==9.0.4
     # via
     #   -r requirements/doc.in
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
-sphinx-rtd-theme==3.0.2
+sphinx-rtd-theme==3.1.0
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -61,7 +61,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.4
+sqlparse==0.5.5
     # via django
-urllib3==2.6.2
+urllib3==2.6.3
     # via requests

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,13 @@
 #
 #    make upgrade
 #
-wheel==0.45.1
+packaging==26.0
+    # via wheel
+wheel==0.46.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==26.0.1
     # via -r requirements/pip.in
-setuptools==80.9.0
+setuptools==82.0.0
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,19 +4,21 @@
 #
 #    make upgrade
 #
-build==1.3.0
+build==1.4.0
     # via pip-tools
 click==8.3.1
     # via pip-tools
-packaging==25.0
-    # via build
-pip-tools==7.5.2
+packaging==26.0
+    # via
+    #   build
+    #   wheel
+pip-tools==7.5.3
     # via -r requirements/pip_tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.45.1
+wheel==0.46.3
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,13 +7,13 @@
     # via
     #   -r requirements/base.txt
     #   django
-astroid==3.3.11
+astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
 backports-tarfile==1.2.0
     # via jaraco-context
-certifi==2025.11.12
+certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
@@ -28,38 +28,38 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==2.3.0
     # via edx-lint
-coverage[toml]==7.13.0
+coverage[toml]==7.13.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==46.0.3
+cryptography==46.0.5
     # via secretstorage
-dill==0.4.0
+dill==0.4.1
     # via pylint
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
 django-dynamic-fixture==4.0.1
     # via -r requirements/test.in
-docutils==0.22.3
+docutils==0.22.4
     # via readme-renderer
 edx-lint==5.6.0
     # via -r requirements/test.in
-id==1.5.0
+id==1.6.1
     # via twine
 idna==3.11
     # via requests
-importlib-metadata==8.7.0
+importlib-metadata==8.7.1
     # via keyring
 iniconfig==2.3.0
     # via pytest
-isort==6.1.0
+isort==8.0.1
     # via pylint
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.0
     # via keyring
-jaraco-functools==4.3.0
+jaraco-functools==4.4.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -83,13 +83,14 @@ more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.2
+nh3==0.3.3
     # via readme-renderer
-packaging==25.0
+packaging==26.0
     # via
     #   pytest
     #   twine
-platformdirs==4.5.1
+    #   wheel
+platformdirs==4.9.2
     # via pylint
 pluggy==1.6.0
     # via
@@ -97,14 +98,14 @@ pluggy==1.6.0
     #   pytest-cov
 pycodestyle==2.14.0
     # via -r requirements/test.in
-pycparser==2.23
+pycparser==3.0
     # via cffi
 pygments==2.19.2
     # via
     #   pytest
     #   readme-renderer
     #   rich
-pylint==3.3.9
+pylint==4.0.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -112,7 +113,7 @@ pylint==3.3.9
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
 pylint-plugin-utils==0.9.0
     # via
@@ -124,7 +125,7 @@ pytest==9.0.2
     #   pytest-django
 pytest-cov==7.0.0
     # via -r requirements/test.in
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/test.in
 python-slugify==8.0.4
     # via code-annotations
@@ -134,40 +135,40 @@ readme-renderer==44.0
     # via twine
 requests==2.32.5
     # via
-    #   id
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==14.2.0
+rich==14.3.3
     # via twine
 secretstorage==3.5.0
     # via keyring
 six==1.17.0
     # via edx-lint
-sqlparse==0.5.4
+sqlparse==0.5.5
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.6.0
+stevedore==5.7.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.13.3
+tomlkit==0.14.0
     # via pylint
 twine==6.2.0
     # via -r requirements/test.in
-urllib3==2.6.2
+urllib3==2.6.3
     # via
+    #   id
     #   requests
     #   twine
-wheel==0.45.1
+wheel==0.46.3
     # via -r requirements/test.in
 zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==80.9.0
+setuptools==82.0.0
     # via -r requirements/test.in

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,31 +4,33 @@
 #
 #    make upgrade
 #
-cachetools==6.2.3
-    # via tox
-chardet==5.2.0
+cachetools==7.0.1
     # via tox
 colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.20.0
+filelock==3.25.0
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
-packaging==25.0
+packaging==26.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.5.1
+platformdirs==4.9.2
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-tox==4.32.0
+python-discovery==1.1.0
+    # via virtualenv
+tox==4.47.0
     # via -r requirements/tox.in
-virtualenv==20.35.4
+virtualenv==21.1.0
     # via tox


### PR DESCRIPTION
Update to the latest pip-tools and re-build requirements to fix the
upgrade job.  To do this I manually updated to the latest pip-tools and
then re-built everything else with that version by commenting out the
first line of the `upgrade` make target temporarily.

Fixes https://github.com/openedx/i18n-tools/actions/runs/22556579391/job/65334966865