### PR TITLE
Dropped django 4.2 support. Bumped dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Change Log
 Unreleased
 ----------
 
+* Dropped Django 4.2 support; bumped code-annotations to 3.0.0, edx-lint to 6.0.0
+
 5.1.0 - 2025-04-18
 ---------------------
 * Added Support for ``django 5.2``.

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==7.0.4
+cachetools==7.0.5
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -16,7 +16,7 @@ distlib==0.4.0
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   -r requirements/tox.txt
     #   python-discovery
@@ -41,7 +41,7 @@ pyproject-api==1.10.0
     # via
     #   -r requirements/tox.txt
     #   tox
-python-discovery==1.1.1
+python-discovery==1.2.0
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -49,9 +49,9 @@ tomli-w==1.2.0
     # via
     #   -r requirements/tox.txt
     #   tox
-tox==4.49.0
+tox==4.50.3
     # via -r requirements/tox.txt
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,7 +12,7 @@ babel==2.18.0
     # via sphinx
 certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.5
+charset-normalizer==3.4.6
     # via requests
 django==5.2.12
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ wheel==0.46.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==26.0.1
     # via -r requirements/pip.in
-setuptools==82.0.0
+setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,9 +13,7 @@ astroid==4.0.4
     #   pylint-celery
 certifi==2026.2.25
     # via requests
-cffi==2.0.0
-    # via cryptography
-charset-normalizer==3.4.5
+charset-normalizer==3.4.6
     # via requests
 click==8.3.1
     # via
@@ -24,14 +22,12 @@ click==8.3.1
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via edx-lint
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==46.0.5
-    # via secretstorage
 dill==0.4.1
     # via pylint
     # via
@@ -41,7 +37,7 @@ django-dynamic-fixture==4.0.1
     # via -r requirements/test.in
 docutils==0.22.4
     # via readme-renderer
-edx-lint==5.6.0
+edx-lint==6.0.0
     # via -r requirements/test.in
 id==1.6.1
     # via twine
@@ -53,14 +49,10 @@ isort==8.0.1
     # via pylint
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.1.1
+jaraco-context==6.1.2
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via code-annotations
 keyring==25.7.0
@@ -94,8 +86,6 @@ pluggy==1.6.0
     #   pytest-cov
 pycodestyle==2.14.0
     # via -r requirements/test.in
-pycparser==3.0
-    # via cffi
 pygments==2.19.2
     # via
     #   pytest
@@ -119,7 +109,7 @@ pytest==9.0.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in
 pytest-django==4.12.0
     # via -r requirements/test.in
@@ -139,8 +129,6 @@ rfc3986==2.0.0
     # via twine
 rich==14.3.3
     # via twine
-secretstorage==3.5.0
-    # via keyring
 six==1.17.0
     # via edx-lint
 sqlparse==0.5.5
@@ -164,5 +152,5 @@ wheel==0.46.3
     # via -r requirements/test.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==82.0.0
+setuptools==82.0.1
     # via -r requirements/test.in

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-cachetools==7.0.4
+cachetools==7.0.5
     # via tox
 colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   python-discovery
     #   tox
@@ -28,11 +28,11 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.1.1
+python-discovery==1.2.0
     # via virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.50.3
     # via -r requirements/tox.in
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via tox

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ setup(
         'Intended Audience :: Developers',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.2',
     ],
     keywords='Django sites edx',


### PR DESCRIPTION
Dropped django 4.2 support. Bumped dependencies

Issue: https://github.com/openedx/public-engineering/issues/458