### PR TITLE
Replace deprecated utcnow() with now(datetime.UTC)

### DIFF
--- a/django_sites_extensions/__init__.py
+++ b/django_sites_extensions/__init__.py
@@ -1,2 +1,2 @@
 """ django_sites_extensions main module """
-__version__ = '6.0.0'
+__version__ = '6.0.1'

--- a/django_sites_extensions/models.py
+++ b/django_sites_extensions/models.py
@@ -66,7 +66,7 @@ def patched_get_site_by_id(self, site_id):
     Site model's relationship accessors to take effect without having to manual
     recycle all Django worker processes active in an application environment.
     """
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
     site = models.SITE_CACHE.get(site_id)
     cache_timeout = SITE_CACHE_TIMEOUTS.get(site_id, now)
     if not site or cache_timeout <= now:
@@ -88,7 +88,7 @@ def patched_get_site_by_request(self, request):
     recycle all Django worker processes active in an application environment.
     """
     host = request.get_host()
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
     site = models.SITE_CACHE.get(host)
     cache_timeout = SITE_CACHE_TIMEOUTS.get(host, now)
     if not site or cache_timeout <= now:

--- a/django_sites_extensions/tests/test_models.py
+++ b/django_sites_extensions/tests/test_models.py
@@ -51,7 +51,7 @@ class PatchedSiteManagerTestCase(TestCase):
         """
         request = HttpRequest()
         request.META['HTTP_HOST'] = self.foo_site.domain
-        past = datetime.datetime.utcnow() - datetime.timedelta(0, 300)
+        past = datetime.datetime.now(datetime.UTC) - datetime.timedelta(0, 300)
 
         # Test getting current site by request host
         site = Site.objects.get_current(request)


### PR DESCRIPTION
Fixes this warning seen when running LMS/CMS:

```
WARNING 39 [py.warnings] [user None] [ip 192.168.65.1] warnings.py:112 -
/openedx/venv/lib/python3.12/site-packages/django_sites_extensions/models.py:69:
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version.
Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```